### PR TITLE
split-card-render

### DIFF
--- a/angular-ui/src/app/card-component/card.component.css
+++ b/angular-ui/src/app/card-component/card.component.css
@@ -1,3 +1,8 @@
+@font-face {
+  font-family: bebas;
+  src: url("../../assets/fonts/BEBAS.ttf") format("truetype");
+}
+
 h1 {
   color: #369;
   font-family: Arial, Helvetica, sans-serif;
@@ -13,6 +18,12 @@ pre {
 hr {
   visibility: hidden;
   margin-bottom: -1px;
+}
+
+.bside-text {
+  text-align: center;
+  font-size: 200%;
+  font-family: bebas, sans-serif;
 }
 
 /*For debug purposes */

--- a/angular-ui/src/app/card-component/card.component.html
+++ b/angular-ui/src/app/card-component/card.component.html
@@ -21,6 +21,14 @@
     <div *ngIf="card.power" class="card-pt">{{card.power}} / {{card.toughness}}</div>
     <div *ngIf="card.loyalty" class="card-loyalty">{{card.loyalty}}</div>
   </div>
+  <div *ngIf="bSide">
+    <br/><br/>
+    <pre class="bside-text">This    card    has    a    {{card.layout}}    side:</pre>
+    <card-component [card]="bSide"></card-component>
+  </div>
+  <div *ngIf="isBSide">
+    <pre class="bside-text">This    card    is    the    second    side    of    a    {{card.layout}}    card</pre>
+  </div>
 </div>
 
 <ng-template #no_card>No card found...</ng-template>

--- a/angular-ui/src/app/card-component/card.component.ts
+++ b/angular-ui/src/app/card-component/card.component.ts
@@ -13,7 +13,9 @@ export class CardComponent implements OnChanges{
 
   @Input() card: Card;
 
-  cardName: string;
+  bSide: Card;
+  isBSide: boolean = false;
+
   templateStyle: string[];
   parsedCardCost = '<b>Loading...</b>';
   parsedCardText: string;
@@ -26,6 +28,16 @@ export class CardComponent implements OnChanges{
       this.setTemplateStyle(this.card.types, this.card.colors);
       this.parsedCardCost = CardUtil.parseAllSymbols(this.card.manaCost, this.card.name);
       this.parsedCardText = CardUtil.parseAllSymbols(this.card.text, this.card.name);
+
+      // set the card's second side if it is a split/transform/etc card, otherwise indicate that the current card is the second side
+      if(this.card.names.length > 1) {
+        if(this.card.names[1] === this.card.name) {
+          this.isBSide = true;
+        }
+        else {
+          this.cardService.search(this.card.names[1]).then(card => this.bSide = card);
+        }
+      }
     }
   }
 

--- a/angular-ui/src/app/search/search.component.ts
+++ b/angular-ui/src/app/search/search.component.ts
@@ -27,7 +27,6 @@ export class SearchComponent {
     this.cardService.search(cardName).then(foundCard => {
       this.card = foundCard;
       this.setTemplateStyle(this.card.types, this.card.colors);
-      console.log(`{"name": ${this.card.name}, "validity": ${this.card.validity}, "tags": ${this.card.tags.toString()}`);
       this.parsedCardCost = CardUtil.parseAllSymbols(this.card.manaCost, this.card.name);
       this.parsedCardText = CardUtil.parseAllSymbols(this.card.text, this.card.name);
     });


### PR DESCRIPTION
* if a card has a split/transform/second card face, it will now be shown as a separate card after the first card template
  * the type of layout (split/transform/etc) will be indicated
* due to the way that I just hacked some existing python scripts to convert rnn card output into json format, the second part of a two part card (b-side) does not indicate the name of the first part of the card in the names field, so we may need to implement some sort of lookup function to retrieve the first part of the card when given just the b-side
* for the b-side of a two part card, there will be some text to indicate that it is the second part