### PR TITLE
war-deploy: enables project to be built into a single .war file

### DIFF
--- a/angular-ui/.angular-cli.json
+++ b/angular-ui/.angular-cli.json
@@ -6,7 +6,7 @@
   "apps": [
     {
       "root": "src",
-      "outDir": "dist",
+      "outDir": "../src/main/resources/static",
       "assets": [
         "assets",
         "favicon.ico"

--- a/build.gradle
+++ b/build.gradle
@@ -10,21 +10,77 @@ buildscript {
 	}
 }
 
-apply plugin: 'java'
-apply plugin: 'eclipse'
-apply plugin: 'org.springframework.boot'
+plugins {
+	id "java"
+	id "idea"
+	id "application"
+	id "com.moowork.node" version "1.2.0"
+}
 
-group = 'mtg'
-version = '0.0.1-SNAPSHOT'
-sourceCompatibility = 1.8
+apply plugin: 'org.springframework.boot'
+apply plugin: 'io.spring.dependency-management'
+apply plugin: 'war'
 
 repositories {
 	mavenCentral()
+	maven { url "http://repo.spring.io/plugins-release" }
+	maven { url "http://repo.spring.io/milestone" }
 }
 
+mainClassName = "mtg.rnn.sort" + ".MtgRnnSortApplication"
+
+group = 'mtg'
+
+defaultTasks 'clean', 'build'
+
+node {
+	download = true
+}
+
+node {
+	// Version of node to use.
+	version = '8.4.0'
+
+	// Version of npm to use.
+	npmVersion = '5.4.0'
+}
+
+task installClient(type: NpmTask) {
+	description = 'Install node modules'
+	workingDir = file("${project.projectDir}/angular-ui")
+	args = ['install']
+}
+
+task buildClient(type: NpmTask) {
+	description = 'Compile client side folder for development'
+	workingDir = file("${project.projectDir}/angular-ui")
+	args = ['run-script', 'build']
+}
+
+war {
+	archiveName = "mtg-rnn-sort.war"
+}
+
+jar {
+	archiveName = "mtg-rnn-sort.jar"
+}
+
+jar.into('static') {
+	from('src/main/webapp')
+}
+
+task wrapper(type: Wrapper) {
+	gradleVersion = '4.1'
+}
 
 dependencies {
 	compile('org.springframework.boot:spring-boot-starter-data-mongodb')
 	compile('org.springframework.boot:spring-boot-starter-web')
 	testCompile('org.springframework.boot:spring-boot-starter-test')
 }
+
+buildClient.dependsOn installClient
+war.dependsOn buildClient
+jar.dependsOn buildClient
+build.dependsOn buildClient
+run.dependsOn war

--- a/src/main/java/mtg/rnn/sort/MtgRnnSortApplication.java
+++ b/src/main/java/mtg/rnn/sort/MtgRnnSortApplication.java
@@ -2,11 +2,18 @@ package mtg.rnn.sort;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.web.support.SpringBootServletInitializer;
 
 @SpringBootApplication
-public class MtgRnnSortApplication {
+public class MtgRnnSortApplication extends SpringBootServletInitializer {
 
 	public static void main(String[] args) {
 		SpringApplication.run(MtgRnnSortApplication.class, args);
+	}
+
+	@Override
+	protected SpringApplicationBuilder configure(SpringApplicationBuilder builder) {
+		return builder.sources(MtgRnnSortApplication.class);
 	}
 }


### PR DESCRIPTION
* modifies build.gradle to:
  * compile all of the angular files into javascript and dump them into the spring resources/static directory
  * package the whole spring server up into a .war file that can be easily deployed to heroku
  * spring will serve the angular content from resources/static

* TODO:  due to the way that angular routing works, when navigating to/from angular pages, it with intercept requests for certain pages and render them correctly. However, if you manually enter the page url or try to refresh a page other than the main index page, spring will try to find and render the page (rather than angular), and you'll get a 404. We'll have to try to mess around with the way that page routing works to try to get angular to intercept (or spring to pass through) manual url entry and the like